### PR TITLE
ViewModel deserialization changes

### DIFF
--- a/Styleguide.Tests/Properties/AssemblyInfo.cs
+++ b/Styleguide.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Styleguide.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Styleguide.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("C89754ED-8EBD-405A-9152-DF9ABEA4C650")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Styleguide.Tests/Styleguide.Tests.csproj
+++ b/Styleguide.Tests/Styleguide.Tests.csproj
@@ -1,0 +1,65 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{C89754ED-8EBD-405A-9152-DF9ABEA4C650}</ProjectGuid>
+    <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Styleguide.Tests</RootNamespace>
+    <AssemblyName>Styleguide.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+    <Reference Include="nunit.framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb">
+      <HintPath>..\packages\NUnit.3.5.0\lib\net45\nunit.framework.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ViewModelDeserializerTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Styleguide\Styleguide.csproj">
+      <Project>{84ebe80b-8bbe-43c5-a7ef-6cc22b4c14fa}</Project>
+      <Name>Styleguide</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+         Other similar extension points exist, see Microsoft.Common.targets.
+    <Target Name="BeforeBuild">
+    </Target>
+    <Target Name="AfterBuild">
+    </Target>
+    -->
+</Project>

--- a/Styleguide.Tests/ViewModelDeserializerTests.cs
+++ b/Styleguide.Tests/ViewModelDeserializerTests.cs
@@ -1,0 +1,94 @@
+﻿using System.Linq;
+using Forte.Styleguide;
+using NUnit.Framework;
+
+namespace Styleguide.Tests
+{
+    [TestFixture]
+    public class ViewModelDeserializerTests
+    {
+        [Test]
+        public void GivenJson_Deserialize_ReturnsValidViewModel()
+        {
+            //given
+            var content = @"{
+              ""model"" : {
+                ""name""  : ""John"",
+                ""label"" : ""CEO""
+              },
+              ""variants"":[
+                {
+                  ""name"" : ""Vertical layout""
+                }
+              ]
+            }";
+            
+
+            //when
+            var viewModel = ViewModelDeserializer.Deserialize(typeof(DummyViewModel), content, "Test");
+            
+            //then
+            Assert.AreEqual("Test", viewModel.Name);
+            Assert.AreEqual(1, viewModel.Variants.Count());
+
+            var variant = viewModel.Variants.First();
+            Assert.AreEqual(typeof(DummyViewModel), variant.Model.GetType());
+            Assert.AreEqual("Vertical layout", variant.Name);
+
+            var model = (DummyViewModel) variant.Model;
+            Assert.AreEqual("John", model.Name);
+            Assert.AreEqual("CEO", model.Label);
+            
+        }
+
+        [Test]
+        public void GivenJsonWithVariants_Deserialize_ReturnsValidViewModel()
+        {
+            //given
+            var content = @"{
+              ""model"" : {
+                ""name""  : ""John"",
+                ""label"" : ""CEO""
+              },
+              ""variants"":[
+                {
+                  ""name"" : ""Vertical layout""
+                },
+                {
+                  ""name"" : ""Horizontal layout"",
+                  ""model"" : {
+                    ""label"": ""CTO""
+                  }
+                }
+              ]
+            }";
+          
+            //when
+            var viewModel = ViewModelDeserializer.Deserialize(typeof(DummyViewModel), content, "Test");
+            Assert.AreEqual(2, viewModel.Variants.Count());
+           
+            var verticalVariant = viewModel.Variants.First();
+            Assert.AreEqual(typeof(DummyViewModel), verticalVariant.Model.GetType());
+            Assert.AreEqual("Vertical layout", verticalVariant.Name);
+  
+            var verticalModel = (DummyViewModel) verticalVariant.Model;
+            Assert.AreEqual("John", verticalModel.Name);
+            Assert.AreEqual("CEO", verticalModel.Label);
+
+            var horizontalVariant = viewModel.Variants.Last();
+            Assert.AreEqual(typeof(DummyViewModel), horizontalVariant.Model.GetType());
+            Assert.AreEqual("Horizontal layout", horizontalVariant.Name);
+    
+            var horizontalModel = (DummyViewModel) horizontalVariant.Model;
+            Assert.AreEqual("John", horizontalModel.Name);
+            Assert.AreEqual("CTO", horizontalModel.Label);
+
+        }
+      
+        private class DummyViewModel
+        {
+          public string Name { get; set; }
+          public string Label { get; set; }
+        }
+    }
+}

--- a/Styleguide.Tests/ViewModelDeserializerTests.cs
+++ b/Styleguide.Tests/ViewModelDeserializerTests.cs
@@ -65,6 +65,8 @@ namespace Styleguide.Tests
           
             //when
             var viewModel = ViewModelDeserializer.Deserialize(typeof(DummyViewModel), content, "Test");
+          
+            //then
             Assert.AreEqual(2, viewModel.Variants.Count());
            
             var verticalVariant = viewModel.Variants.First();
@@ -83,6 +85,82 @@ namespace Styleguide.Tests
             Assert.AreEqual("John", horizontalModel.Name);
             Assert.AreEqual("CTO", horizontalModel.Label);
 
+        }
+
+        [Test]
+        public void GivenJsonWithStringModel_Deserialize_ReturnsValidViewModel()
+        {
+            //given
+            var content = @"{
+                  ""model"" : ""default string"",
+                  ""variants"":[
+                    {
+                      ""name"" : ""Vertical layout""
+                    },
+                    {
+                      ""name"" : ""Horizontal layout"",
+                      ""model"" : ""overriden string""
+                    }
+                  ]
+                }";
+            
+            //when
+            var viewModel = ViewModelDeserializer.Deserialize(typeof(string), content, "Test");
+            
+            //then
+            Assert.AreEqual(2, viewModel.Variants.Count());
+          
+            var verticalVariant = viewModel.Variants.First();
+            Assert.AreEqual(typeof(string), verticalVariant.Model.GetType());
+            Assert.AreEqual("Vertical layout", verticalVariant.Name);
+      
+            var verticalModel = (string) verticalVariant.Model;
+            Assert.AreEqual("default string", verticalModel);
+          
+            var horizontalVariant = viewModel.Variants.Last();
+            Assert.AreEqual(typeof(string), horizontalVariant.Model.GetType());
+            Assert.AreEqual("Horizontal layout", horizontalVariant.Name);
+        
+            var horizontalModel = (string) horizontalVariant.Model;
+            Assert.AreEqual("overriden string", horizontalModel);
+        }
+      
+        [Test]
+        public void GivenJsonWithIntModel_Deserialize_ReturnsValidViewModel()
+        {
+            //given
+            var content = @"{
+                      ""model"" : 1,
+                      ""variants"":[
+                        {
+                          ""name"" : ""Vertical layout""
+                        },
+                        {
+                          ""name"" : ""Horizontal layout"",
+                          ""model"" : 2
+                        }
+                      ]
+                    }";
+                
+            //when
+            var viewModel = ViewModelDeserializer.Deserialize(typeof(int), content, "Test");
+                
+            //then
+            Assert.AreEqual(2, viewModel.Variants.Count());
+              
+            var verticalVariant = viewModel.Variants.First();
+            Assert.AreEqual(typeof(int), verticalVariant.Model.GetType());
+            Assert.AreEqual("Vertical layout", verticalVariant.Name);
+          
+            var verticalModel = (int) verticalVariant.Model;
+            Assert.AreEqual(1, verticalModel);
+              
+            var horizontalVariant = viewModel.Variants.Last();
+            Assert.AreEqual(typeof(int), horizontalVariant.Model.GetType());
+            Assert.AreEqual("Horizontal layout", horizontalVariant.Name);
+            
+            var horizontalModel = (int) horizontalVariant.Model;
+            Assert.AreEqual(2, horizontalModel);
         }
       
         private class DummyViewModel

--- a/Styleguide.Tests/packages.config
+++ b/Styleguide.Tests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="3.5.0" targetFramework="net45" />
+</packages>

--- a/Styleguide.sln
+++ b/Styleguide.sln
@@ -6,6 +6,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Styleguide", "Styleguide\St
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Styleguide.EPiServer", "Styleguide.EPiServer\Styleguide.EPiServer.csproj", "{ADC8830C-C42D-412E-A6CE-26B06E52A0C1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Styleguide.Tests", "Styleguide.Tests\Styleguide.Tests.csproj", "{C89754ED-8EBD-405A-9152-DF9ABEA4C650}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -20,6 +22,10 @@ Global
 		{ADC8830C-C42D-412E-A6CE-26B06E52A0C1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{ADC8830C-C42D-412E-A6CE-26B06E52A0C1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{ADC8830C-C42D-412E-A6CE-26B06E52A0C1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C89754ED-8EBD-405A-9152-DF9ABEA4C650}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C89754ED-8EBD-405A-9152-DF9ABEA4C650}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C89754ED-8EBD-405A-9152-DF9ABEA4C650}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C89754ED-8EBD-405A-9152-DF9ABEA4C650}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Styleguide/Controllers/StyleGuideController.cs
+++ b/Styleguide/Controllers/StyleGuideController.cs
@@ -1,6 +1,5 @@
-﻿using System.IO;
-using System.Linq;
-using System.Net;
+﻿using System.Net;
+using System.Threading.Tasks;
 using System.Web.Mvc;
 
 namespace Forte.Styleguide
@@ -22,7 +21,7 @@ namespace Forte.Styleguide
             return View(model);
         }
 
-        public ActionResult Component(string name)
+        public async Task<ActionResult> Component(string name)
         {
             if (string.IsNullOrEmpty(name))            
                 return new HttpStatusCodeResult(HttpStatusCode.BadRequest, "Name of the component is not defined");            
@@ -31,7 +30,7 @@ namespace Forte.Styleguide
             if (component == null)
                 return HttpNotFound();
 
-            return component.Execute(ControllerContext);
+            return await component.Execute(ControllerContext);
         }
 
         [HttpGet]

--- a/Styleguide/IStyleguideComponentDescriptor.cs
+++ b/Styleguide/IStyleguideComponentDescriptor.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Threading.Tasks;
 using System.Web.Mvc;
 
 namespace Forte.Styleguide
@@ -8,6 +9,6 @@ namespace Forte.Styleguide
         string Name { get; }
         string Category { get; }
         FileInfo File { get; }
-        ActionResult Execute(ControllerContext context);
+        Task<ActionResult> Execute(ControllerContext context);
     }
 }

--- a/Styleguide/MvcPartialComponentDescriptor.cs
+++ b/Styleguide/MvcPartialComponentDescriptor.cs
@@ -33,10 +33,13 @@ namespace Forte.Styleguide
 
             var viewModelType = this.ResolveViewModelType(view);
 
-            var jsonContent = await this.File.OpenText().ReadToEndAsync();
-            var viewModel = ViewModelDeserializer.Deserialize(viewModelType, jsonContent, this.Name, this.serializerSettings);
-
-            return PartialView(context, viewModel);
+            using (var reader = this.File.OpenText())
+            {
+                var jsonContent = await reader.ReadToEndAsync();
+                var viewModel = ViewModelDeserializer.Deserialize(viewModelType, jsonContent, this.Name, this.serializerSettings);
+                
+                return PartialView(context, viewModel);
+            }
         }
 
         private static PartialViewResult PartialView(ControllerContext context, MvcPartialComponentViewModel model)

--- a/Styleguide/MvcPartialComponentDescriptor.cs
+++ b/Styleguide/MvcPartialComponentDescriptor.cs
@@ -2,11 +2,10 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Web.Compilation;
 using System.Web.Mvc;
-using Forte.Styleguide.Converters;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace Forte.Styleguide
 {
@@ -26,7 +25,7 @@ namespace Forte.Styleguide
             this.serializerSettings = serializerSettings;
         }
 
-        public ActionResult Execute(ControllerContext context)
+        public async Task<ActionResult> Execute(ControllerContext context)
         {
             var view = this.FindPartialView(context, this.Name);
             if (view == null)
@@ -34,7 +33,8 @@ namespace Forte.Styleguide
 
             var viewModelType = this.ResolveViewModelType(view);
 
-            var viewModel = this.LoadComponentViewModel(viewModelType);
+            var jsonContent = await this.File.OpenText().ReadToEndAsync();
+            var viewModel = ViewModelDeserializer.Deserialize(viewModelType, jsonContent, this.Name, this.serializerSettings);
 
             return PartialView(context, viewModel);
         }
@@ -49,59 +49,6 @@ namespace Forte.Styleguide
                 ViewData = new ViewDataDictionary(model),
                 ViewEngineCollection = ViewEngines.Engines
             };
-        }
-
-        private MvcPartialComponentViewModel LoadComponentViewModel(Type viewModelType)
-        {
-            var serializer = JsonSerializer.Create(this.serializerSettings);
-            
-            var viewModelBuilder = new MvcPartialComponentViewModelBuilder()
-                .WithName(this.Name)
-                .WithPartialName(this.Name);
-            
-            using (var reader = this.File.OpenText())
-            {
-                var desc = serializer.Deserialize(reader, typeof(object));
-                if (desc is JArray value)
-                {
-                    var variants = value.Select(i => i.ToObject(viewModelType, serializer));
-
-                    foreach (var variant in variants)
-                    {
-                        viewModelBuilder = viewModelBuilder.WithVariant(builder => builder.WithModel(variant));
-                    }
-                }
-                
-                if(desc is JObject jObject)
-                {
-                    serializer.Converters.Add(new MvcPartialComponentVariantViewModelConverter(viewModelType));
-
-                    var rootModelJsonObject = jObject.SelectToken("model") ?? new JObject();
-                    var rootModel = rootModelJsonObject?.ToObject(viewModelType, serializer);
-                    
-                    var variantsToken = jObject.SelectToken("variants"); 
-                    var variantsModelTokens = variantsToken?.Select(token => token.SelectToken("model"));
-                    
-                    foreach (var variantModelToken in variantsModelTokens ?? Enumerable.Empty<JToken>())
-                    {
-                        var rootModelCopy = rootModelJsonObject.DeepClone();
-                        if (rootModelCopy is JContainer container)
-                        {
-                            container.Merge(variantModelToken);
-                            variantModelToken.Replace(rootModelCopy);
-                        }
-                    }
-
-                    var variantsAfterMerge = variantsToken?.ToObject<MvcPartialComponentVariantViewModel[]>(serializer) ?? new MvcPartialComponentVariantViewModel[0];
-                    
-                    viewModelBuilder = viewModelBuilder
-                        .WithPartialName(jObject.SelectToken("layout")?.ToObject<string>(serializer))
-                        .WithModel(rootModel)
-                        .WithVariants(variantsAfterMerge);
-                }
-
-                return viewModelBuilder.Build();
-            }
         }
 
         private Type ResolveViewModelType(BuildManagerCompiledView view)

--- a/Styleguide/Styleguide.csproj
+++ b/Styleguide/Styleguide.csproj
@@ -76,6 +76,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="MvcPartialComponentDescriptor.cs" />
     <Compile Include="StringExtensions.cs" />
+    <Compile Include="ViewModelDeserializer.cs" />
     <Compile Include="Views\Styleguide\MvcPartialComponentContextViewModel.cs" />
     <Compile Include="Views\Styleguide\MvcPartialComponentVariantViewModel.cs" />
     <Compile Include="Views\Styleguide\MvcPartialComponentVariantViewModelBuilder.cs" />

--- a/Styleguide/ViewModelDeserializer.cs
+++ b/Styleguide/ViewModelDeserializer.cs
@@ -42,16 +42,24 @@ namespace Forte.Styleguide
                 var variantsList = new List<MvcPartialComponentVariantViewModel>();
                 foreach (var variant in variantsToken)
                 {
-                    var rootModelCopy = rootModelJsonObject.DeepClone();
-                    if (!(rootModelCopy is JContainer container)) continue;
-                    
                     var variantModel = variant.SelectToken("model");
-                    container.Merge(variantModel);
-                    variantsList.Add(new MvcPartialComponentVariantViewModel
+                    var viewModel = new MvcPartialComponentVariantViewModel
                     {
-                        Model = container.ToObject(viewModelType, serializer),
-                        Name = variant.SelectToken("name").ToString()
-                    });
+                        Name = variant.SelectToken("name").ToString(),
+                    };
+                    
+                    if (rootModelJsonObject is JContainer container)
+                    {
+                        container.Merge(variantModel);
+                        viewModel.Model = container.ToObject(viewModelType, serializer);
+                    }
+
+                    if (rootModelJsonObject is JValue)
+                    {
+                        viewModel.Model = variantModel != null ? variantModel.ToObject(viewModelType) : rootModel;
+                    }
+                    
+                    variantsList.Add(viewModel);
                 }
                 
                 viewModelBuilder = viewModelBuilder

--- a/Styleguide/ViewModelDeserializer.cs
+++ b/Styleguide/ViewModelDeserializer.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Forte.Styleguide.Converters;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Forte.Styleguide
+{
+    public static class ViewModelDeserializer
+    {
+        public static MvcPartialComponentViewModel Deserialize(Type viewModelType, string jsonContent, string name, JsonSerializerSettings serializerSettings = null)
+        {
+            if (serializerSettings == null) serializerSettings = new JsonSerializerSettings();
+            
+            var serializer = JsonSerializer.Create(serializerSettings);
+            
+            var viewModelBuilder = new MvcPartialComponentViewModelBuilder()
+                .WithName(name)
+                .WithPartialName(name);
+
+            var desc = JsonConvert.DeserializeObject(jsonContent, serializerSettings);            
+            if (desc is JArray value)
+            {
+                var variants = value.Select(i => i.ToObject(viewModelType, serializer));
+
+                foreach (var variant in variants)
+                {
+                    viewModelBuilder = viewModelBuilder.WithVariant(builder => builder.WithModel(variant));
+                }
+            }
+            
+            if(desc is JObject jObject)
+            {
+                serializer.Converters.Add(new MvcPartialComponentVariantViewModelConverter(viewModelType));
+
+                var rootModelJsonObject = jObject.SelectToken("model") ?? new JObject();
+                var rootModel = rootModelJsonObject?.ToObject(viewModelType, serializer);
+                
+                var variantsToken = jObject.SelectToken("variants");
+                
+                var variantsList = new List<MvcPartialComponentVariantViewModel>();
+                foreach (var variant in variantsToken)
+                {
+                    var rootModelCopy = rootModelJsonObject.DeepClone();
+                    if (!(rootModelCopy is JContainer container)) continue;
+                    
+                    var variantModel = variant.SelectToken("model");
+                    container.Merge(variantModel);
+                    variantsList.Add(new MvcPartialComponentVariantViewModel
+                    {
+                        Model = container.ToObject(viewModelType, serializer),
+                        Name = variant.SelectToken("name").ToString()
+                    });
+                }
+                
+                viewModelBuilder = viewModelBuilder
+                    .WithPartialName(jObject.SelectToken("layout")?.ToObject<string>(serializer))
+                    .WithModel(rootModel)
+                    .WithVariants(variantsList.ToArray());
+            }
+
+            return viewModelBuilder.Build();
+        }
+    }
+}


### PR DESCRIPTION
Previously `model` entry on `variant` level was mandatory - you had to pass empty `model: {}`, without it deserialization crashed.

This PR is a fix for this issue.

I did some refactoring (moved deserialization logic to external class) and added tests 