### PR TITLE
Fix null Master language for localizable content

### DIFF
--- a/Styleguide.EPiServer/ContentProvider/StyleguideContentFactory.cs
+++ b/Styleguide.EPiServer/ContentProvider/StyleguideContentFactory.cs
@@ -72,6 +72,7 @@ namespace Forte.Styleguide.EPiServer.ContentProvider
             if (content is ILocalizable localizable)
             {
                 localizable.Language = new CultureInfo("no");
+                localizable.MasterLanguage = localizable.Language;
             }
 
             if (content is IVersionable versionable)


### PR DESCRIPTION
When using StyleGuideContentFactory, Language property was set
to "no", but Master language remained null