### PR TITLE
support blocks in contentarea

### DIFF
--- a/Styleguide.EPiServer/ContainerExtensions.cs
+++ b/Styleguide.EPiServer/ContainerExtensions.cs
@@ -34,7 +34,8 @@ namespace Forte.Styleguide.EPiServer
                 config.For<IStyleguideContentFactory>().Add(c => new StyleguideContentFactory(
                     StyleguideContentEntryPoint.Ensure(c.GetInstance<IContentRepository>()),
                     c.GetInstance<IContentTypeRepository>(),
-                    c.GetInstance<IContentFactory>()));
+                    c.GetInstance<IContentFactory>(), 
+                    c.GetInstance<ISharedBlockFactory>()));
                 
                 config.For<IStyleguideContentRepository>().Add<StyleguideContentRepository>();
                 


### PR DESCRIPTION
This change fixes an issue where Styleguide was not able to render blocks defined inside of ContentArea.